### PR TITLE
Fix deprecation cop

### DIFF
--- a/styles/components/atom-text-editor.less
+++ b/styles/components/atom-text-editor.less
@@ -1,4 +1,4 @@
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -50,18 +50,16 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .bracket-matcher .region{
     border-radius: 2px;
     border: 1px solid fadeout(@very-light-gray, 40%);

--- a/styles/components/comment.less
+++ b/styles/components/comment.less
@@ -1,4 +1,4 @@
-.comment {
+.syntax--comment {
   color: @light-gray;
   font-style: italic;
 }

--- a/styles/components/constant.less
+++ b/styles/components/constant.less
@@ -1,24 +1,24 @@
-.constant {
+.syntax--constant {
   color: @red;
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @cyan;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: darken(@pink, 20%);
   }
 
-  &.other {
+  &.syntax--other {
     color: @red;
   }
 
-  &.other.color,
-  &.other.rgb-value {
+  &.syntax--other.syntax--color,
+  &.syntax--other.syntax--rgb-value {
     color: darken(@pink, 20%);
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @green;
   }
 }

--- a/styles/components/entity.less
+++ b/styles/components/entity.less
@@ -1,38 +1,38 @@
-.entity {
-  &.name.type {
+.syntax--entity {
+  &.syntax--name.syntax--type {
     color: @light-orange;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @green;
   }
 }
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @blue;
   }
 
-  &.name.class, &.name.type.class {
+  &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
     color: @light-orange;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @blue;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @green;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @syntax-text-color;
 
-    &.css {
+    &.syntax--css {
       color: @green;
     }
 
-    &.id {
-      &.css {
+    &.syntax--id {
+      &.syntax--css {
         color: @green;
       }
       color: @syntax-text-color;

--- a/styles/components/keyword.less
+++ b/styles/components/keyword.less
@@ -1,22 +1,22 @@
-.keyword {
+.syntax--keyword {
   color: @green;
 
-  &.control {
+  &.syntax--control {
     color: @green;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @syntax-text-color;
-    &.regexp {
+    &.syntax--regexp {
       color: @cyan;
     }
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @blue;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: darken(@pink, 10%);
   }
 }

--- a/styles/components/markup.less
+++ b/styles/components/markup.less
@@ -1,39 +1,39 @@
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @orange;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @purple;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @red;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @purple;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @blue;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @green;
   }
 
-  &.list {
+  &.syntax--list {
     color: @red;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @orange;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @green;
   }
 }

--- a/styles/components/meta.less
+++ b/styles/components/meta.less
@@ -1,21 +1,21 @@
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @light-orange;
   }
 
-  &.link {
+  &.syntax--link {
     color: @orange;
   }
 
-  &.require {
+  &.syntax--require {
     color: @blue;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @purple;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @gray;
     color: @syntax-text-color;
   }

--- a/styles/components/punctuation.less
+++ b/styles/components/punctuation.less
@@ -1,82 +1,82 @@
-.sgml .punctuation.definition.tag {
+.style--sgml .style--punctuation.style--definition.style--tag {
   color: @syntax-text-color;
 }
 
-.punctuation {
-  &.section {
+.style--punctuation {
+  &.style--section {
     color: @natural;
   }
-  &.scss {
+  &.style--scss {
     color: @syntax-text-color;
   }
-  &.json {
-    &.separator {
+  &.style--json {
+    &.style--separator {
       color: @natural;
     }
   }
-  &.definition {
-    &.comment {
+  &.style--definition {
+    &.style--comment {
       color: @light-gray;
     }
 
-    &.json {
-      &.array,
-      &.dictionary {
+    &.style--json {
+      &.style--array,
+      &.style--dictionary {
         color: @natural;
       }
     }
 
-    &.css,
-    &.less,
-    &.scss {
-      &.entity {
+    &.style--css,
+    &.style--less,
+    &.style--scss {
+      &.style--entity {
         color: @cyan;
       }
-      &.constant {
+      &.style--constant {
         color: darken(@pink, 10%);
       }
     }
 
-    &.string.begin.json,
-    &.string.end.json {
+    &.style--string.style--begin.style--json,
+    &.style--string.style--end.style--json {
       color: lighten(@red, 25%);
     }
 
-    &.string,
-    &.variable,
-    &.array {
+    &.style--string,
+    &.style--variable,
+    &.style--array {
       color: darken(@pink, 10%);
     }
 
-    &.regexp {
+    &.style--regexp {
       color: @cyan;
     }
 
-    &.parameters{
+    &.style--parameters{
       color: darken(@cyan, 10%);
     }
 
-    &.tag {
+    &.style--tag {
       color: darken(@green, 20%);
     }
 
-    &.heading,
-    &.identity {
+    &.style--heading,
+    &.style--identity {
       color: @blue;
     }
 
-    &.bold {
+    &.style--bold {
       color: @light-orange;
       font-weight: bold;
     }
 
-    &.italic {
+    &.style--italic {
       color: @purple;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
+  &.style--section.style--embedded {
     color: darken(@red, 10%);
   }
 

--- a/styles/components/source.less
+++ b/styles/components/source.less
@@ -1,30 +1,30 @@
 
-.source {
+.syntax--source {
 
-  .json {
+  .syntax--json {
     color: lighten(@red, 15%);
   }
 
-  &.gfm {
-    .link {
+  &.syntax--gfm {
+    .syntax--link {
       color: @blue;
     }
-    .list {
+    .syntax--list {
       color: @red;
     }
-    .markup {
+    .syntax--markup {
       -webkit-font-smoothing: auto;
-      &.heading {
+      &.syntax--heading {
         color: @green;
       }
-      &.link {
+      &.syntax--link {
         color: @cyan;
       }
-      &.bold {
+      &.syntax--bold {
         font-style: bold;
         color: @syntax-text-color;
       }
-      &.italic {
+      &.syntax--italic {
         font-style: italic;
         color: @syntax-text-color;
       }

--- a/styles/components/storage.less
+++ b/styles/components/storage.less
@@ -1,3 +1,3 @@
-.storage {
+.syntax--storage {
   color: @green;
 }

--- a/styles/components/string.less
+++ b/styles/components/string.less
@@ -1,11 +1,11 @@
-.string {
+.syntax--string {
   color: @pink;
 
-  &.regexp {
+  &.syntax--regexp {
     color: @pink;
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @red;
   }
 }

--- a/styles/components/support.less
+++ b/styles/components/support.less
@@ -1,11 +1,11 @@
-.support {
-  &.class,
-  &.function,
-  &.constant {
+.syntax--support {
+  &.syntax--class,
+  &.syntax--function,
+  &.syntax--constant {
     color: @syntax-text-color;
   }
 
-  &.gfm {
+  &.syntax--gfm {
     color: @red;
   }
 }

--- a/styles/components/variable.less
+++ b/styles/components/variable.less
@@ -1,16 +1,16 @@
-.variable {
+.syntax--variable {
   color: @syntax-text-color;
 
-  &.less,
-  &.scss {
+  &.syntax--less,
+  &.syntax--scss {
     color: @blue;
   }
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: darken(@red, 10%);
   }
 
-  &.parameter.function {
+  &.syntax--parameter.syntax--function {
     color: @cyan;
   }
 }


### PR DESCRIPTION
This fixes deprecations from Atom v1.1.2 by removing ":host", replacing "::shadow" with ".editor", and properly prepending syntax selectors with ".syntax--". Fixes issue #4.